### PR TITLE
Change all timestamps to utc_datetime_usec

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,9 @@ import Config
 config :dashfloat,
   namespace: DashFloat,
   ecto_repos: [DashFloat.Repo],
-  generators: [timestamp_type: :utc_datetime]
+  generators: [timestamp_type: :utc_datetime_usec]
+
+config :dashfloat, DashFloat.Repo, migration_timestamps: [type: :timestamptz]
 
 # Configures the endpoint
 config :dashfloat, DashFloatWeb.Endpoint,

--- a/lib/dashfloat/contexts/identity/schemas/user.ex
+++ b/lib/dashfloat/contexts/identity/schemas/user.ex
@@ -14,18 +14,18 @@ defmodule DashFloat.Identity.Schemas.User do
           email: String.t() | nil,
           password: String.t() | nil,
           hashed_password: String.t() | nil,
-          confirmed_at: NaiveDateTime.t() | nil,
-          inserted_at: NaiveDateTime.t() | nil,
-          updated_at: NaiveDateTime.t() | nil
+          confirmed_at: DateTime.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
 
   schema "users" do
     field :email, :string
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
-    field :confirmed_at, :naive_datetime
+    field :confirmed_at, :utc_datetime_usec
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc """
@@ -146,8 +146,7 @@ defmodule DashFloat.Identity.Schemas.User do
   """
   @spec confirm_changeset(t() | Ecto.Changeset.t()) :: Ecto.Changeset.t()
   def confirm_changeset(user) do
-    now = NaiveDateTime.utc_now()
-    change(user, confirmed_at: NaiveDateTime.truncate(now, :second))
+    change(user, confirmed_at: DateTime.utc_now())
   end
 
   @doc """

--- a/lib/dashfloat/contexts/identity/schemas/user_token.ex
+++ b/lib/dashfloat/contexts/identity/schemas/user_token.ex
@@ -21,7 +21,7 @@ defmodule DashFloat.Identity.Schemas.UserToken do
           context: String.t() | nil,
           sent_to: String.t() | nil,
           user_id: integer() | nil,
-          inserted_at: NaiveDateTime.t() | nil
+          inserted_at: DateTime.t() | nil
         }
 
   schema "users_tokens" do
@@ -30,7 +30,7 @@ defmodule DashFloat.Identity.Schemas.UserToken do
     field :sent_to, :string
     belongs_to :user, User
 
-    timestamps(updated_at: false)
+    timestamps(type: :utc_datetime_usec, updated_at: false)
   end
 
   @doc false

--- a/priv/repo/migrations/20231027210812_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20231027210812_create_users_auth_tables.exs
@@ -7,8 +7,8 @@ defmodule DashFloat.Repo.Migrations.CreateUsersAuthTables do
     create table(:users) do
       add :email, :citext, null: false
       add :hashed_password, :string, null: false
-      add :confirmed_at, :naive_datetime
-      timestamps()
+      add :confirmed_at, :timestamptz
+      timestamps(type: :timestamptz)
     end
 
     create unique_index(:users, [:email])
@@ -18,7 +18,7 @@ defmodule DashFloat.Repo.Migrations.CreateUsersAuthTables do
       add :token, :binary, null: false
       add :context, :string, null: false
       add :sent_to, :string
-      timestamps(updated_at: false)
+      timestamps(type: :timestamptz, updated_at: false)
     end
 
     create index(:users_tokens, [:user_id])

--- a/test/support/factories/identity_factory.ex
+++ b/test/support/factories/identity_factory.ex
@@ -21,7 +21,7 @@ defmodule DashFloat.Factories.IdentityFactory do
     struct!(
       user_factory(),
       %{
-        confirmed_at: NaiveDateTime.utc_now()
+        confirmed_at: DateTime.utc_now()
       }
     )
   end


### PR DESCRIPTION
This changes all datetime-based columns from naive_datetime to timestamptz for migrations and utc_datetime_usec for schemas.

This also sets the generators to use the correct datetime type.

This is to make sure that time is always accurate.

For more reading:
https://stackoverflow.com/questions/22922155/postgresql-jdbc-and-timestamp-vs-timestamptz