### PR TITLE
Add Continuous Deployment to Fly.io

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,0 +1,21 @@
+name: Deploy (Production)
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  deploy:
+    name: Deploy To Production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Fly
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        run: flyctl deploy --remote-only -c fly.production.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_PRODUCTION_API_TOKEN }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,21 @@
+name: Deploy (Staging)
+on:
+  push:
+    pull_request:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy To Staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Fly
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        run: flyctl deploy --remote-only -c fly.staging.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_STAGING_API_TOKEN }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,7 +1,7 @@
 name: Deploy (Staging)
 on:
   push:
-    pull_request:
+    branches:
       - main
 
 jobs:

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -1,0 +1,29 @@
+# fly.toml app configuration file generated for dashfloat-production on 2023-11-20T12:02:31Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "dashfloat-production"
+primary_region = "sin"
+kill_signal = "SIGTERM"
+
+[build]
+
+[deploy]
+  release_command = "/app/bin/migrate"
+
+[env]
+  PHX_HOST = "dashfloat-production.fly.dev"
+  PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 1000
+    soft_limit = 1000

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,0 +1,29 @@
+# fly.toml app configuration file generated for dashfloat-staging on 2023-11-20T11:53:23Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "dashfloat-staging"
+primary_region = "sin"
+kill_signal = "SIGTERM"
+
+[build]
+
+[deploy]
+  release_command = "/app/bin/migrate"
+
+[env]
+  PHX_HOST = "dashfloat-staging.fly.dev"
+  PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 1000
+    soft_limit = 1000

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# configure node for distributed erlang with IPV6 support
+export ERL_AFLAGS="-proto_dist inet6_tcp"
+export ECTO_IPV6="true"
+export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
+export RELEASE_DISTRIBUTION="name"
+export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"


### PR DESCRIPTION
I changed my mind about GCP because Cloud SQL is ridiculously expensive that I would have to go outside of GCP for my managed database needs.

I figured I should just settle for Fly because I won't have to go outside as much.