### PR TITLE
Change host used in Fly deployments

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -48,7 +48,13 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
-  host = System.get_env("PHX_HOST") || "example.com"
+  host =
+    System.get_env("PHX_HOST") ||
+      raise """
+      environment variable PHX_HOST is missing.
+      For example: example.com
+      """
+
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :dashfloat, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -13,7 +13,7 @@ kill_signal = "SIGTERM"
   release_command = "/app/bin/migrate"
 
 [env]
-  PHX_HOST = "dashfloat-production.fly.dev"
+  PHX_HOST = "www.dashfloat.com"
   PORT = "8080"
 
 [http_service]

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -13,7 +13,7 @@ kill_signal = "SIGTERM"
   release_command = "/app/bin/migrate"
 
 [env]
-  PHX_HOST = "dashfloat-staging.fly.dev"
+  PHX_HOST = "staging.dashfloat.com"
   PORT = "8080"
 
 [http_service]


### PR DESCRIPTION
This changes PHX_HOST to use the custom domains instead of the ones used internally by Fly to make Phoenix LiveView work.