### PR TITLE
Integrate PostMark for email sending

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -109,10 +109,10 @@ if config_env() == :prod do
   # Also, you may need to configure the Swoosh API client of your choice if you
   # are not using SMTP. Here is an example of the configuration:
   #
-  #     config :dashfloat, DashFloat.Mailer,
-  #       adapter: Swoosh.Adapters.Mailgun,
-  #       api_key: System.get_env("MAILGUN_API_KEY"),
-  #       domain: System.get_env("MAILGUN_DOMAIN")
+  config :dashfloat, DashFloat.Mailer,
+    adapter: Swoosh.Adapters.Postmark,
+    api_key: System.get_env("POSTMARK_API_KEY")
+
   #
   # For this example you need include a HTTP client required by Swoosh API client.
   # Swoosh supports Hackney and Finch out of the box:

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -15,6 +15,7 @@ kill_signal = "SIGTERM"
 [env]
   PHX_HOST = "www.dashfloat.com"
   PORT = "8080"
+  MAIL_HOST = "dashfloat.com"
 
 [http_service]
   internal_port = 8080

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -15,6 +15,7 @@ kill_signal = "SIGTERM"
 [env]
   PHX_HOST = "staging.dashfloat.com"
   PORT = "8080"
+  MAIL_HOST = "dashfloat.com"
 
 [http_service]
   internal_port = 8080

--- a/lib/dashfloat/contexts/identity/emails/confirmation_instructions_email.ex
+++ b/lib/dashfloat/contexts/identity/emails/confirmation_instructions_email.ex
@@ -5,6 +5,7 @@ defmodule DashFloat.Identity.Emails.ConfirmationInstructionsEmail do
 
   import Swoosh.Email
 
+  alias DashFloat.Identity.Helpers.EmailHelper
   alias DashFloat.Identity.Schemas.User
 
   @spec call(
@@ -16,8 +17,8 @@ defmodule DashFloat.Identity.Emails.ConfirmationInstructionsEmail do
 
     new()
     |> to(user.email)
-    |> from({"DashFloat", "contact@example.com"})
-    |> subject("Confirmation instructions")
+    |> from(EmailHelper.no_reply())
+    |> subject("Confirmation Instructions")
     |> text_body(body)
   end
 

--- a/lib/dashfloat/contexts/identity/emails/reset_password_instructions_email.ex
+++ b/lib/dashfloat/contexts/identity/emails/reset_password_instructions_email.ex
@@ -5,6 +5,7 @@ defmodule DashFloat.Identity.Emails.ResetPasswordInstructionsEmail do
 
   import Swoosh.Email
 
+  alias DashFloat.Identity.Helpers.EmailHelper
   alias DashFloat.Identity.Schemas.User
 
   @spec call(
@@ -16,8 +17,8 @@ defmodule DashFloat.Identity.Emails.ResetPasswordInstructionsEmail do
 
     new()
     |> to(user.email)
-    |> from({"DashFloat", "contact@example.com"})
-    |> subject("Reset password instructions")
+    |> from(EmailHelper.no_reply())
+    |> subject("Reset Password Instructions")
     |> text_body(body)
   end
 

--- a/lib/dashfloat/contexts/identity/emails/update_email_instructions_email.ex
+++ b/lib/dashfloat/contexts/identity/emails/update_email_instructions_email.ex
@@ -5,6 +5,7 @@ defmodule DashFloat.Identity.Emails.UpdateEmailInstructionsEmail do
 
   import Swoosh.Email
 
+  alias DashFloat.Identity.Helpers.EmailHelper
   alias DashFloat.Identity.Schemas.User
 
   @spec call(
@@ -16,8 +17,8 @@ defmodule DashFloat.Identity.Emails.UpdateEmailInstructionsEmail do
 
     new()
     |> to(user.email)
-    |> from({"DashFloat", "contact@example.com"})
-    |> subject("Update email instructions")
+    |> from(EmailHelper.no_reply())
+    |> subject("Update Email Instructions")
     |> text_body(body)
   end
 

--- a/lib/dashfloat/contexts/identity/helpers/email_helper.ex
+++ b/lib/dashfloat/contexts/identity/helpers/email_helper.ex
@@ -1,0 +1,33 @@
+defmodule DashFloat.Identity.Helpers.EmailHelper do
+  @moduledoc """
+  Helper functions for building emails.
+  """
+
+  @app_name "DashFloat"
+  @default_domain "example.com"
+
+  @doc """
+  Returns a tuple of the no-reply email address.
+
+  ## Examples
+
+      iex> EmailHelper.no_reply()
+      {"DashFloat", "no-reply@dashfloat.com"}
+  """
+  @spec no_reply() :: {String.t(), String.t()}
+  def no_reply do
+    {sender_name(), "no-reply@#{mail_host()}"}
+  end
+
+  defp sender_name do
+    if String.contains?(mail_host(), "staging") do
+      @app_name <> " Staging"
+    else
+      @app_name
+    end
+  end
+
+  defp mail_host do
+    System.get_env("MAIL_HOST") || @default_domain
+  end
+end

--- a/test/dashfloat/contexts/identity/helpers/email_helper_test.exs
+++ b/test/dashfloat/contexts/identity/helpers/email_helper_test.exs
@@ -1,0 +1,25 @@
+defmodule Dashfloat.Identity.Helpers.EmailHelperTest do
+  use DashFloat.DataCase, async: true
+
+  alias DashFloat.Identity.Helpers.EmailHelper
+
+  describe "no_reply/0" do
+    test "with MAIL_HOST returns a no-reply email address in the correct domain" do
+      System.put_env("MAIL_HOST", "dashfloat.com")
+
+      assert EmailHelper.no_reply() == {"DashFloat", "no-reply@dashfloat.com"}
+    end
+
+    test "with MAIL_HOST that has staging returns a no-reply email address in the correct domain" do
+      System.put_env("MAIL_HOST", "staging.dashfloat.com")
+
+      assert EmailHelper.no_reply() == {"DashFloat Staging", "no-reply@staging.dashfloat.com"}
+    end
+
+    test "with no MAIL_HOST returns a no-reply email address in the default domain" do
+      System.delete_env("MAIL_HOST")
+
+      assert EmailHelper.no_reply() == {"DashFloat", "no-reply@example.com"}
+    end
+  end
+end


### PR DESCRIPTION
This adds PostMark as the service used for sending emails.

This also improves the email being sent to look more professional.