### PR TITLE
Restrict Deployment only after CI has succeeded

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,13 +1,18 @@
 name: Deploy (Staging)
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
-      - main
+      - deploy-after-ci
 
 jobs:
   deploy:
     name: Deploy To Staging
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
     branches:
-      - deploy-after-ci
+      - *
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
     branches:
-      - 'deploy-after-ci'
+      - '*'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
     branches:
-      - *
+      - 'deploy-after-ci'
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -5,8 +5,6 @@ on:
       - CI
     types:
       - completed
-    branches:
-      - '*'
 
 jobs:
   deploy:


### PR DESCRIPTION
We have to make sure that the code actually works first before we attempt to do any deployments.